### PR TITLE
Backward apiary compatibility: allow pushing queueName within mqOptions

### DIFF
--- a/src/queues/ironmq.coffee
+++ b/src/queues/ironmq.coffee
@@ -185,7 +185,7 @@ class IronMQQueue
   listen: (mqOptions, queues, cb) ->
     if typeof queues is 'function'
       cb = queues
-      queues = [@getQueueName()]
+      queues = [@getQueueName(mqOptions.queueName)]
 
     @listening = true
     async.series [

--- a/src/queues/memory.coffee
+++ b/src/queues/memory.coffee
@@ -90,7 +90,7 @@ class MemoryQueue
   listen: (mqOptions, queues, cb) ->
     if typeof queues is 'function'
       cb = queues
-      queues = [@getQueueName()]
+      queues = [@getQueueName(mqOptions.queueName)]
 
     @listening = true
     @consumeInterval = setInterval (=> @consumeTasks(queues) if @listening), CONSUME_INTERVAL unless @consumeInterval


### PR DESCRIPTION
Used by workers in Apiary